### PR TITLE
DnsMonitor Datasource isn't honoring the timeout

### DIFF
--- a/ZenPacks/zenoss/DnsMonitor/datasources/DnsMonitorDataSource.py
+++ b/ZenPacks/zenoss/DnsMonitor/datasources/DnsMonitorDataSource.py
@@ -87,6 +87,8 @@ class DnsMonitorDataSource(ZenPackPersistence, RRDDataSource.RRDDataSource):
             parts.append('-s "%s"' % self.dnsServer)
         if self.expectedIpAddress:
             parts.append('-a %s' % self.expectedIpAddress)
+        if self.timeout:
+            parts.append('-t %d' % self.timeout)
         cmd = ' '.join(parts)
         cmd = RRDDataSource.RRDDataSource.getCommand(self, context, cmd)
         return cmd


### PR DESCRIPTION
The timeout is always using the built-in check_dns value of 10s regardless of what you set the template to.
