### PR TITLE
ZEN-29750: Default DNSMonitor template uses dev/id rather than dev/manageIP for the DNS…

### DIFF
--- a/ZenPacks/zenoss/DnsMonitor/datasources/DnsMonitorDataSource.py
+++ b/ZenPacks/zenoss/DnsMonitor/datasources/DnsMonitorDataSource.py
@@ -49,11 +49,7 @@ class DnsMonitorDataSource(PythonDataSource):
     sourcetype = DNS_MONITOR
     plugin_classname = (
         ZENPACKID + '.datasources.DnsMonitorDataSource.DnsMonitorDataSourcePlugin')
-    timeout = 15
-    eventClass = '/Status/DNS'
-    hostname = '${dev/id}'
     dnsServer = ''
-    expectedIpAddress = ''
 
     _properties = PythonDataSource._properties + (
         {'id':'hostname', 'type':'string', 'mode':'w'},

--- a/ZenPacks/zenoss/DnsMonitor/objects/objects.xml
+++ b/ZenPacks/zenoss/DnsMonitor/objects/objects.xml
@@ -26,7 +26,7 @@ True
 900
 </property>
 <property type="string" id="hostname" mode="w" >
-${dev/id}
+${dev/titleOrId}
 </property>
 <property type="string" id="expectedIpAddress" mode="w" >
 ${dev/manageIp}


### PR DESCRIPTION
… Server field