### PR TITLE
ZEN-29750: Default DNSMonitor template uses dev/id rather than dev/ma…

### DIFF
--- a/ZenPacks/zenoss/DnsMonitor/datasources/DnsMonitorDataSource.py
+++ b/ZenPacks/zenoss/DnsMonitor/datasources/DnsMonitorDataSource.py
@@ -49,7 +49,11 @@ class DnsMonitorDataSource(PythonDataSource):
     sourcetype = DNS_MONITOR
     plugin_classname = (
         ZENPACKID + '.datasources.DnsMonitorDataSource.DnsMonitorDataSourcePlugin')
+    timeout = 15
+    eventClass = '/Status/DNS'
+    hostname = '${dev/titleOrId}'    
     dnsServer = ''
+    expectedIpAddress = ''
 
     _properties = PythonDataSource._properties + (
         {'id':'hostname', 'type':'string', 'mode':'w'},


### PR DESCRIPTION
…nageIP for the DNS Server field