### PR TITLE
ZPS-4190: DNSMonitor doesn't create datapoint by default

### DIFF
--- a/ZenPacks/zenoss/DnsMonitor/datasources/DnsMonitorDataSource.py
+++ b/ZenPacks/zenoss/DnsMonitor/datasources/DnsMonitorDataSource.py
@@ -62,6 +62,10 @@ class DnsMonitorDataSource(PythonDataSource):
         {'id':'timeout', 'type':'int', 'mode':'w'},
         )
 
+    def addDataPoints(self):
+        if not self.datapoints._getOb('time', None):
+            self.manage_addRRDDataPoint('time')
+
 
 class DnsMonitorDataSourcePlugin(PythonDataSourcePlugin):
 


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZPS-4190?focusedCommentId=134310&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-134310